### PR TITLE
Fix function of clear button

### DIFF
--- a/mapdisplay.js
+++ b/mapdisplay.js
@@ -265,7 +265,7 @@ function clearMap()
 
   $("#dataMapDateSliderContainer").hide()
   $("#dateDisplay").hide()
-  $("#sourceToggleButton").html("Display")
+  $("#sourceToggleButton").html("Select Source")
   currentMapSource = FiveThirtyEightPollAverageMapSource
 
   showingDataMap = false


### PR DESCRIPTION
The clear button still sets the source select button to "display". This will set it to "Select Source".